### PR TITLE
Add build workflow with badge

### DIFF
--- a/.github/workflows/go-build.yml
+++ b/.github/workflows/go-build.yml
@@ -1,0 +1,23 @@
+name: Build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Build server
+        run: go build ./cmd/server
+      - name: Build client
+        run: go build ./cmd/client

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # mgrok
 
+[![Build](https://github.com/markCwatson/mgrok/actions/workflows/go-build.yml/badge.svg)](https://github.com/markCwatson/mgrok/actions/workflows/go-build.yml)
+
 A tunneling application for exposing local servers behind NATs and firewalls to the internet. In the demo below, the mgrok server (top-left) and client (top-right) are running concurrently. A local web server on port 8080 (bottom-left) hosts a simple HTML page; then, from the bottom-right tab I 'curl' the mgrok server's public port 8000. The request is forwarded over the tunnel to the client, which fetches the page from localhost:8080 and sends it back through the server to 'curl'.
 
 ![alt-text][8]


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow that builds mgrok on Linux, macOS and Windows
- show build status badge in README

## Testing
- `go test ./...` *(fails: no route to host)*